### PR TITLE
Fix styling on Google Chrome

### DIFF
--- a/website/website/src/templates/index.rs
+++ b/website/website/src/templates/index.rs
@@ -27,13 +27,12 @@ pub fn index_page() -> SycamoreTemplate<G> {
                         ) { (t!("index-get-started")) }
                         a(
                             // The difference in y-axis padding is deliberate, it looks better with the ring
-                            class = "py-2 px-4 m-2 font-semibold rounded-lg shadow-2xl dark:text-white ring-4 ring-indigo-500 hover:ring-indigo-400 transition-colors duration-200",
-                            href = "https://github.com/arctic-hen7/perseus",
-                            // I genuinely have no clue why this works, but it does
-                            style = "display: ruby;"
+                            class = "inline-flex items-center py-2 px-4 m-2 font-semibold rounded-lg shadow-2xl dark:text-white ring-4 ring-indigo-500 hover:ring-indigo-400 transition-colors duration-200",
+                            href = "https://github.com/arctic-hen7/perseus"
                         ) {
                             span(
-                               dangerously_set_inner_html = GITHUB_SVG
+                                class = "m-1",
+                                dangerously_set_inner_html = GITHUB_SVG
                             )
                             span { (format!(" {}", t!("index-github"))) }
                         }


### PR DESCRIPTION
The styling on chrome is a bit broken because it does not support `display: ruby`. Also according to https://stackoverflow.com/questions/42897783/what-is-displayruby, it seems like `display: ruby` is being misused in this case.

![image](https://user-images.githubusercontent.com/37006668/136496359-10c243f6-279f-4def-8d86-2ba6ff027f35.png)
