### PR TITLE
docs: add instruction to replace perseus_integration

### DIFF
--- a/examples/.base/src/main.rs
+++ b/examples/.base/src/main.rs
@@ -3,7 +3,13 @@ mod templates;
 
 use perseus::{Html, PerseusApp};
 
-#[perseus::main(perseus_integration::dflt_server)]
+
+/// Replace `<perseus_integration>` with an integration of your choice.
+/// Examples of supported integrations:
+/// - perseus_warp (use this one if you follow basic tutorials)
+/// - perseus-actix-web
+/// - perseus-axum
+#[perseus::main(<perseus_integration>::dflt_server)]
 pub fn main<G: Html>() -> PerseusApp<G> {
     PerseusApp::new()
         .template(crate::templates::index::get_template)

--- a/examples/.base/src/main.rs
+++ b/examples/.base/src/main.rs
@@ -6,7 +6,7 @@ use perseus::{Html, PerseusApp};
 
 /// Replace `<perseus_integration>` with an integration of your choice.
 /// Examples of supported integrations:
-/// - perseus_warp (use this one if you follow basic tutorials)
+/// - perseus_warp (recommended)
 /// - perseus-actix-web
 /// - perseus-axum
 #[perseus::main(<perseus_integration>::dflt_server)]


### PR DESCRIPTION
I didn't want to edit your in-depth explanation from the foldable pane, and without that, it would be kind of duplication, so instead, I opted to add a comment to the main.rs example. That way, if someone just copies the code, he'll have information right there, without the need to dig through the page.

I saw other integrations, so I added them, but maybe you don't want them exposed - let me know if you want some tweaking on this.