### PR TITLE
docs: update reference link to index_view main.rs

### DIFF
--- a/docs/0.3.4/en-US/reference/index-view.md
+++ b/docs/0.3.4/en-US/reference/index-view.md
@@ -5,7 +5,7 @@ In most Perseus apps, you can just focus on building your app's templates, and l
 However, if you're using Perseus, you probably don't want to be writing HTML right? You're supposed to be using Sycamore! Well, that's completely true, and so Perseus supports creating an index view with Sycamore code! You can do this like so:
 
 ```rust
-{{#include ../../../examples/core/index_view/src/lib.rs}}
+{{#include ../../../examples/core/index_view/src/main.rs}}
 ```
 
 Note that you can also use `.index_view_str()` to provide an arbitrary HTML string to use instead of Sycamore code.


### PR DESCRIPTION
The docs for version 0.3.4 for index_view do not have a working code example as the view is missing Sycamore context.
The changes were made in July but are not showing probably because of the wrong path to the code snippet(though, I don't know why the old file snippet is still showing - is it being skipped due to an error when rendering, so it stays unchanged?)

Here is how it looks like on docs page:
![image](https://user-images.githubusercontent.com/11314775/193212401-4f78f7c7-efec-43d8-ad09-bb2a04ebdd35.png)
(cx: Scope is missing)