### PR TITLE
Use child scopes for pages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [
 	"packages/*",
     "examples/core/*",
     "examples/demos/*",
-    "examples/comprehensive/*",
+    # "examples/comprehensive/*",
     "examples/website/*",
     "website",
     # We have the CLI subcrates as workspace members so we can actively develop on them

--- a/examples/core/plugins/src/plugin.rs
+++ b/examples/core/plugins/src/plugin.rs
@@ -24,7 +24,11 @@ pub fn get_test_plugin<G: perseus::Html>() -> Plugin<G, TestPluginData> {
                     if let Some(plugin_data) = plugin_data.downcast_ref::<TestPluginData>() {
                         let about_page_greeting = plugin_data.about_page_greeting.to_string();
                         vec![Template::new("about").template(
-                            move |cx, _| sycamore::view! { cx,  p { (about_page_greeting) } },
+                            // This is the kind of weird thing we have to do if we don't use the
+                            // macros
+                            move |cx, curr_view, _, _| {
+                                curr_view.set(sycamore::view! { cx,  p { (about_page_greeting) } })
+                            },
                         )]
                     } else {
                         unreachable!()

--- a/examples/core/plugins/src/plugin.rs
+++ b/examples/core/plugins/src/plugin.rs
@@ -26,8 +26,10 @@ pub fn get_test_plugin<G: perseus::Html>() -> Plugin<G, TestPluginData> {
                         vec![Template::new("about").template(
                             // This is the kind of weird thing we have to do if we don't use the
                             // macros
-                            move |cx, curr_view, _, _| {
-                                curr_view.set(sycamore::view! { cx,  p { (about_page_greeting) } })
+                            move |cx, route_manager, _| {
+                                route_manager.update_view(
+                                    sycamore::view! { cx,  p { (about_page_greeting) } },
+                                )
                             },
                         )]
                     } else {

--- a/examples/core/router_state/src/templates/index.rs
+++ b/examples/core/router_state/src/templates/index.rs
@@ -11,7 +11,10 @@ pub fn router_state_page<G: Html>(cx: Scope) -> View<G> {
         RouterLoadState::Loaded {
             template_name,
             path,
-        } => format!("Loaded {} (template: {}).", path, template_name),
+        } => {
+            perseus::web_log!("Loaded.");
+            format!("Loaded {} (template: {}).", path, template_name)
+        }
         RouterLoadState::Loading {
             template_name,
             path,

--- a/packages/perseus-macro/src/template.rs
+++ b/packages/perseus-macro/src/template.rs
@@ -157,7 +157,7 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
             #vis fn #name<G: ::sycamore::prelude::Html>(
                 cx: ::sycamore::prelude::Scope,
                 curr_view: &::sycamore::prelude::Signal<::sycamore::prelude::View<G>>,
-                scope_disposers: &::sycamore::prelude::Signal<::std::vec::Vec<::sycamore::prelude::ScopeDisposer>>,
+                page_disposer: ::perseus::router::PageDisposer,
                 props: ::perseus::template::PageProps
             ) {
                 use ::perseus::state::{MakeRx, MakeRxRef, RxRef};
@@ -190,10 +190,11 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
                     }
                 };
 
-                ::sycamore::reactive::create_child_scope(cx, |child_cx| {
+                let disposer = ::sycamore::reactive::create_child_scope(cx, |child_cx| {
                     let view = #component_name(cx, props.to_ref_struct(cx));
                     curr_view.set(view);
                 });
+                // page_disposer.update(disposer);
             }
         }
     } else if fn_args.len() == 2 && is_reactive == false {
@@ -216,7 +217,7 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
             #vis fn #name<G: ::sycamore::prelude::Html>(
                 cx: ::sycamore::prelude::Scope,
                 curr_view: &::sycamore::prelude::Signal<::sycamore::prelude::View<G>>,
-                scope_disposers: &::sycamore::prelude::Signal<::std::vec::Vec<::sycamore::prelude::ScopeDisposer>>,
+                page_disposer: ::perseus::router::PageDisposer,
                 props: ::perseus::template::PageProps
             ) {
                 use ::perseus::state::{MakeRx, MakeRxRef, RxRef, MakeUnrx};
@@ -252,10 +253,11 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
                 };
 
                 // The `.make_unrx()` function will just convert back to the user's type
-                ::sycamore::reactive::create_child_scope(cx, |child_cx| {
+                let disposer = ::sycamore::reactive::create_child_scope(cx, |child_cx| {
                     let view = #component_name(cx, props.make_unrx());
                     curr_view.set(view);
                 });
+                // page_disposer.update(disposer);
             }
         }
     } else if fn_args.len() == 1 {
@@ -266,7 +268,7 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
             #vis fn #name<G: ::sycamore::prelude::Html>(
                 cx: ::sycamore::prelude::Scope,
                 curr_view: &::sycamore::prelude::Signal<::sycamore::prelude::View<G>>,
-                scope_disposers: &::sycamore::prelude::Signal<::std::vec::Vec<::sycamore::prelude::ScopeDisposer>>,
+                page_disposer: ::perseus::router::PageDisposer,
                 props: ::perseus::template::PageProps
             ) {
                 use ::perseus::state::{MakeRx, MakeRxRef};
@@ -283,10 +285,11 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
                 let render_ctx = ::perseus::RenderCtx::from_ctx(cx);
                 render_ctx.register_page_no_state(&props.path);
 
-                ::sycamore::reactive::create_child_scope(cx, |child_cx| {
+                let disposer = ::sycamore::reactive::create_child_scope(cx, |child_cx| {
                     let view = #component_name(cx);
                     curr_view.set(view);
                 });
+                // page_disposer.update(disposer);
             }
         }
     } else {

--- a/packages/perseus-macro/src/template.rs
+++ b/packages/perseus-macro/src/template.rs
@@ -156,8 +156,7 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
         quote! {
             #vis fn #name<G: ::sycamore::prelude::Html>(
                 cx: ::sycamore::prelude::Scope,
-                curr_view: &::sycamore::prelude::Signal<::sycamore::prelude::View<G>>,
-                page_disposer: ::perseus::router::PageDisposer,
+                route_manager: ::perseus::router::RouteManager<G>,
                 props: ::perseus::template::PageProps
             ) {
                 use ::perseus::state::{MakeRx, MakeRxRef, RxRef};
@@ -192,7 +191,7 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
 
                 let disposer = ::sycamore::reactive::create_child_scope(cx, |child_cx| {
                     let view = #component_name(cx, props.to_ref_struct(cx));
-                    curr_view.set(view);
+                    route_manager.update_view(view);
                 });
                 // page_disposer.update(disposer);
             }
@@ -216,8 +215,7 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
         quote! {
             #vis fn #name<G: ::sycamore::prelude::Html>(
                 cx: ::sycamore::prelude::Scope,
-                curr_view: &::sycamore::prelude::Signal<::sycamore::prelude::View<G>>,
-                page_disposer: ::perseus::router::PageDisposer,
+                route_manager: ::perseus::router::RouteManager<G>,
                 props: ::perseus::template::PageProps
             ) {
                 use ::perseus::state::{MakeRx, MakeRxRef, RxRef, MakeUnrx};
@@ -255,7 +253,7 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
                 // The `.make_unrx()` function will just convert back to the user's type
                 let disposer = ::sycamore::reactive::create_child_scope(cx, |child_cx| {
                     let view = #component_name(cx, props.make_unrx());
-                    curr_view.set(view);
+                    route_manager.update_view(view);
                 });
                 // page_disposer.update(disposer);
             }
@@ -265,10 +263,10 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
         let cx_arg = &fn_args[0];
         // There are no arguments except for the scope
         quote! {
+            // BUG Need to enforce that `cx` and `route_manager` have the same lifetime...
             #vis fn #name<G: ::sycamore::prelude::Html>(
                 cx: ::sycamore::prelude::Scope,
-                curr_view: &::sycamore::prelude::Signal<::sycamore::prelude::View<G>>,
-                page_disposer: ::perseus::router::PageDisposer,
+                mut route_manager: ::perseus::router::RouteManager<G>,
                 props: ::perseus::template::PageProps
             ) {
                 use ::perseus::state::{MakeRx, MakeRxRef};
@@ -287,9 +285,9 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
 
                 let disposer = ::sycamore::reactive::create_child_scope(cx, |child_cx| {
                     let view = #component_name(cx);
-                    curr_view.set(view);
+                    route_manager.update_view(view);
                 });
-                // page_disposer.update(disposer);
+                route_manager.update_disposer(disposer);
             }
         }
     } else {

--- a/packages/perseus-macro/src/template.rs
+++ b/packages/perseus-macro/src/template.rs
@@ -154,7 +154,12 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
         };
         let name_string = name.to_string();
         quote! {
-            #vis fn #name<G: ::sycamore::prelude::Html>(cx: ::sycamore::prelude::Scope, props: ::perseus::template::PageProps) -> ::sycamore::prelude::View<G> {
+            #vis fn #name<G: ::sycamore::prelude::Html>(
+                cx: ::sycamore::prelude::Scope,
+                curr_view: &::sycamore::prelude::Signal<::sycamore::prelude::View<G>>,
+                scope_disposers: &::sycamore::prelude::Signal<::std::vec::Vec<::sycamore::prelude::ScopeDisposer>>,
+                props: ::perseus::template::PageProps
+            ) {
                 use ::perseus::state::{MakeRx, MakeRxRef, RxRef};
 
                 // The user's function, with Sycamore component annotations and the like preserved
@@ -185,7 +190,10 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
                     }
                 };
 
-                #component_name(cx, props.to_ref_struct(cx))
+                ::sycamore::reactive::create_child_scope(cx, |child_cx| {
+                    let view = #component_name(cx, props.to_ref_struct(cx));
+                    curr_view.set(view);
+                });
             }
         }
     } else if fn_args.len() == 2 && is_reactive == false {
@@ -205,7 +213,12 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
         };
         let name_string = name.to_string();
         quote! {
-            #vis fn #name<G: ::sycamore::prelude::Html>(cx: ::sycamore::prelude::Scope, props: ::perseus::template::PageProps) -> ::sycamore::prelude::View<G> {
+            #vis fn #name<G: ::sycamore::prelude::Html>(
+                cx: ::sycamore::prelude::Scope,
+                curr_view: &::sycamore::prelude::Signal<::sycamore::prelude::View<G>>,
+                scope_disposers: &::sycamore::prelude::Signal<::std::vec::Vec<::sycamore::prelude::ScopeDisposer>>,
+                props: ::perseus::template::PageProps
+            ) {
                 use ::perseus::state::{MakeRx, MakeRxRef, RxRef, MakeUnrx};
 
                 // The user's function, with Sycamore component annotations and the like preserved
@@ -239,7 +252,10 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
                 };
 
                 // The `.make_unrx()` function will just convert back to the user's type
-                #component_name(cx, props.make_unrx())
+                ::sycamore::reactive::create_child_scope(cx, |child_cx| {
+                    let view = #component_name(cx, props.make_unrx());
+                    curr_view.set(view);
+                });
             }
         }
     } else if fn_args.len() == 1 {
@@ -247,7 +263,12 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
         let cx_arg = &fn_args[0];
         // There are no arguments except for the scope
         quote! {
-            #vis fn #name<G: ::sycamore::prelude::Html>(cx: ::sycamore::prelude::Scope, props: ::perseus::template::PageProps) -> ::sycamore::prelude::View<G> {
+            #vis fn #name<G: ::sycamore::prelude::Html>(
+                cx: ::sycamore::prelude::Scope,
+                curr_view: &::sycamore::prelude::Signal<::sycamore::prelude::View<G>>,
+                scope_disposers: &::sycamore::prelude::Signal<::std::vec::Vec<::sycamore::prelude::ScopeDisposer>>,
+                props: ::perseus::template::PageProps
+            ) {
                 use ::perseus::state::{MakeRx, MakeRxRef};
 
                 // The user's function, with Sycamore component annotations and the like preserved
@@ -262,7 +283,10 @@ pub fn template_impl(input: TemplateFn, is_reactive: bool) -> TokenStream {
                 let render_ctx = ::perseus::RenderCtx::from_ctx(cx);
                 render_ctx.register_page_no_state(&props.path);
 
-                #component_name(cx)
+                ::sycamore::reactive::create_child_scope(cx, |child_cx| {
+                    let view = #component_name(cx);
+                    curr_view.set(view);
+                });
             }
         }
     } else {

--- a/packages/perseus/src/client.rs
+++ b/packages/perseus/src/client.rs
@@ -70,6 +70,7 @@ pub fn run_client<M: MutableStore, T: TranslationsManager>(
 
     // This top-level context is what we use for everything, allowing page state to
     // be registered and stored for the lifetime of the app
+    // Note: root lifetime creation occurs here
     #[cfg(feature = "hydrate")]
     sycamore::hydrate_to(move |cx| perseus_router(cx, router_props), &root);
     #[cfg(not(feature = "hydrate"))]

--- a/packages/perseus/src/lib.rs
+++ b/packages/perseus/src/lib.rs
@@ -20,7 +20,6 @@ documentation, and this should mostly be used as a secondary reference source. Y
 
 #![deny(missing_docs)]
 // #![deny(missing_debug_implementations)] // TODO Pending sycamore-rs/sycamore#412
-#![forbid(unsafe_code)]
 #![recursion_limit = "256"] // TODO Do we need this anymore?
 
 /// Utilities for working with the engine-side, particularly with regards to

--- a/packages/perseus/src/router/get_initial_view.rs
+++ b/packages/perseus/src/router/get_initial_view.rs
@@ -174,12 +174,7 @@ pub(crate) fn get_initial_view<'a>(
                     });
                     // Render the actual template to the root (done imperatively due to child
                     // scopes)
-                    template.render_for_template_client(
-                        page_props,
-                        cx,
-                        route_manager,
-                        translator,
-                    );
+                    template.render_for_template_client(page_props, cx, route_manager, translator);
 
                     InitialView::Success
                 }

--- a/packages/perseus/src/router/get_initial_view.rs
+++ b/packages/perseus/src/router/get_initial_view.rs
@@ -23,9 +23,11 @@ use web_sys::Element;
 /// Note that this will automatically update the router state just before it
 /// returns, meaning that any errors that may occur after this function has been
 /// called need to reset the router state to be an error.
-pub(crate) fn get_initial_view(
-    cx: Scope,
+pub(crate) fn get_initial_view<'a>(
+    cx: Scope<'a>,
     path: String, // The full path, not the template path (but parsed a little)
+    curr_view: &'a Signal<View<TemplateNodeType>>,
+    scope_disposers: &'a Signal<Vec<ScopeDisposer<'a>>>,
 ) -> InitialView {
     let render_ctx = RenderCtx::from_ctx(cx);
     let router_state = &render_ctx.router;
@@ -54,7 +56,7 @@ pub(crate) fn get_initial_view(
             // Since we're not requesting anything from the server, we don't need to worry about
             // whether it's an incremental match or not
             was_incremental_match: _,
-        }) => InitialView::View({
+        }) => {
             let path_with_locale = match locale.as_str() {
                 "xx-XX" => path.clone(),
                 locale => format!("{}/{}", locale, &path),
@@ -93,7 +95,7 @@ pub(crate) fn get_initial_view(
                             router_state.set_load_state(RouterLoadState::ErrorLoaded {
                                 path: path_with_locale.clone(),
                             });
-                            return InitialView::View(error_pages.get_view_and_render_head(
+                            return InitialView::Error(error_pages.get_view_and_render_head(
                                 cx,
                                 "*",
                                 500,
@@ -110,7 +112,7 @@ pub(crate) fn get_initial_view(
                             router_state.set_load_state(RouterLoadState::ErrorLoaded {
                                 path: path_with_locale.clone(),
                             });
-                            return InitialView::View(match &err {
+                            return InitialView::Error(match &err {
                                 // These errors happen because we couldn't get a translator, so they
                                 // certainly don't get one
                                 ClientError::FetchError(FetchError::NotOk {
@@ -171,8 +173,17 @@ pub(crate) fn get_initial_view(
                         template_name: path,
                         path: path_with_locale,
                     });
-                    // Return the actual template, for rendering/hydration
-                    template.render_for_template_client(page_props, cx, translator)
+                    // Render the actual template to `curr_view` (done imperatively due to child
+                    // scopes)
+                    template.render_for_template_client(
+                        page_props,
+                        cx,
+                        curr_view,
+                        scope_disposers,
+                        translator,
+                    );
+
+                    InitialView::Success
                 }
                 // We have an error that the server sent down, so we should just return that error
                 // view
@@ -182,7 +193,7 @@ pub(crate) fn get_initial_view(
                         path: path_with_locale.clone(),
                     });
                     // We don't need to replace the head, because the server's handled that for us
-                    error_pages.get_view(cx, &url, status, &err, None)
+                    InitialView::Error(error_pages.get_view(cx, &url, status, &err, None))
                 }
                 // The entire purpose of this function is to work with the initial state, so if this
                 // is true, then we have a problem
@@ -194,17 +205,17 @@ pub(crate) fn get_initial_view(
                     router_state.set_load_state(RouterLoadState::ErrorLoaded {
                         path: path_with_locale.clone(),
                     });
-                    error_pages.get_view_and_render_head(cx, "*", 400, "expected initial state render, found subsequent load (highly likely to be a core perseus bug)", None)
+                    InitialView::Error(error_pages.get_view_and_render_head(cx, "*", 400, "expected initial state render, found subsequent load (highly likely to be a core perseus bug)", None))
                 }
             }
-        }),
+        }
         // If the user is using i18n, then they'll want to detect the locale on any paths
         // missing a locale Those all go to the same system that redirects to the
         // appropriate locale Note that `container` doesn't exist for this scenario
         RouteVerdict::LocaleDetection(path) => {
             InitialView::Redirect(detect_locale(path.clone(), &locales))
         }
-        RouteVerdict::NotFound => InitialView::View({
+        RouteVerdict::NotFound => InitialView::Error({
             checkpoint("not_found");
             if let InitialState::Error(ErrorPageData { url, status, err }) = get_initial_state() {
                 router_state.set_load_state(RouterLoadState::ErrorLoaded { path: url.clone() });
@@ -232,8 +243,14 @@ pub(crate) fn get_initial_view(
 /// A representation of the possible outcomes of getting the view for the
 /// initial load.
 pub(crate) enum InitialView {
-    /// A view is available to be rendered/hydrated.
-    View(View<TemplateNodeType>),
+    /// The page has been successfully rendered and sent through the given
+    /// signal.
+    ///
+    /// Due to the use of child scopes, we can't just return a actual view,
+    /// this has to be done imperatively.
+    Success,
+    /// An error view has been produced, which should replace the current view.
+    Error(View<TemplateNodeType>),
     /// We need to redirect somewhere else, and the path to redirect to is
     /// attached.
     ///

--- a/packages/perseus/src/router/get_initial_view.rs
+++ b/packages/perseus/src/router/get_initial_view.rs
@@ -1,7 +1,7 @@
 use crate::error_pages::ErrorPageData;
 use crate::errors::*;
 use crate::i18n::detect_locale;
-use crate::router::match_route;
+use crate::router::{match_route, PageDisposer};
 use crate::router::{RouteInfo, RouteVerdict, RouterLoadState};
 use crate::template::{PageProps, RenderCtx, TemplateNodeType};
 use crate::utils::checkpoint;
@@ -27,7 +27,7 @@ pub(crate) fn get_initial_view<'a>(
     cx: Scope<'a>,
     path: String, // The full path, not the template path (but parsed a little)
     curr_view: &'a Signal<View<TemplateNodeType>>,
-    scope_disposers: &'a Signal<Vec<ScopeDisposer<'a>>>,
+    scope_disposers: PageDisposer<'a>,
 ) -> InitialView {
     let render_ctx = RenderCtx::from_ctx(cx);
     let router_state = &render_ctx.router;

--- a/packages/perseus/src/router/get_initial_view.rs
+++ b/packages/perseus/src/router/get_initial_view.rs
@@ -1,7 +1,7 @@
 use crate::error_pages::ErrorPageData;
 use crate::errors::*;
 use crate::i18n::detect_locale;
-use crate::router::{match_route, PageDisposer};
+use crate::router::{match_route, RouteManager};
 use crate::router::{RouteInfo, RouteVerdict, RouterLoadState};
 use crate::template::{PageProps, RenderCtx, TemplateNodeType};
 use crate::utils::checkpoint;
@@ -26,8 +26,7 @@ use web_sys::Element;
 pub(crate) fn get_initial_view<'a>(
     cx: Scope<'a>,
     path: String, // The full path, not the template path (but parsed a little)
-    curr_view: &'a Signal<View<TemplateNodeType>>,
-    scope_disposers: PageDisposer<'a>,
+    route_manager: &'a RouteManager<'a, TemplateNodeType>,
 ) -> InitialView {
     let render_ctx = RenderCtx::from_ctx(cx);
     let router_state = &render_ctx.router;
@@ -173,13 +172,12 @@ pub(crate) fn get_initial_view<'a>(
                         template_name: path,
                         path: path_with_locale,
                     });
-                    // Render the actual template to `curr_view` (done imperatively due to child
+                    // Render the actual template to the root (done imperatively due to child
                     // scopes)
                     template.render_for_template_client(
                         page_props,
                         cx,
-                        curr_view,
-                        scope_disposers,
+                        route_manager,
                         translator,
                     );
 

--- a/packages/perseus/src/router/get_subsequent_view.rs
+++ b/packages/perseus/src/router/get_subsequent_view.rs
@@ -1,6 +1,6 @@
 use crate::errors::*;
 use crate::page_data::PageDataPartial;
-use crate::router::{RouteVerdict, RouterLoadState, RouteManager};
+use crate::router::{RouteManager, RouteVerdict, RouterLoadState};
 use crate::state::PssContains;
 use crate::template::{PageProps, RenderCtx, Template, TemplateNodeType};
 use crate::utils::checkpoint;

--- a/packages/perseus/src/router/get_subsequent_view.rs
+++ b/packages/perseus/src/router/get_subsequent_view.rs
@@ -1,6 +1,6 @@
 use crate::errors::*;
 use crate::page_data::PageDataPartial;
-use crate::router::{RouteVerdict, RouterLoadState};
+use crate::router::{RouteVerdict, RouterLoadState, RouteManager};
 use crate::state::PssContains;
 use crate::template::{PageProps, RenderCtx, Template, TemplateNodeType};
 use crate::utils::checkpoint;
@@ -14,14 +14,8 @@ use sycamore::prelude::*;
 pub(crate) struct GetSubsequentViewProps<'a> {
     /// The app's reactive scope.
     pub cx: Scope<'a>,
-    /// The `Signal` for the current view, which will imperatively set by the
-    /// user's template function (due to the use of child scopes).
-    pub curr_view: &'a Signal<View<TemplateNodeType>>,
-    /// The scope disposer for pages, which will be dumped as necessary.
-    ///
-    /// Note that error pages are rendered on the app-level scope, so we don't
-    /// have to worry about them with this.
-    pub scope_disposers: PageDisposer<'a>,
+    /// The app's route manager.
+    pub route_manager: &'a RouteManager<'a, TemplateNodeType>,
     /// The path we're rendering for (not the template path, the full path,
     /// though parsed a little).
     pub path: String,
@@ -52,8 +46,7 @@ pub(crate) struct GetSubsequentViewProps<'a> {
 pub(crate) async fn get_subsequent_view(
     GetSubsequentViewProps {
         cx,
-        curr_view,
-        scope_disposers,
+        route_manager,
         path,
         template,
         was_incremental_match,
@@ -271,7 +264,7 @@ pub(crate) async fn get_subsequent_view(
         path: path_with_locale,
     });
     // Now return the view that should be rendered
-    template.render_for_template_client(page_props, cx, curr_view, scope_disposers, translator);
+    template.render_for_template_client(page_props, cx, route_manager, translator);
     SubsequentView::Success
 }
 

--- a/packages/perseus/src/router/get_subsequent_view.rs
+++ b/packages/perseus/src/router/get_subsequent_view.rs
@@ -14,6 +14,14 @@ use sycamore::prelude::*;
 pub(crate) struct GetSubsequentViewProps<'a> {
     /// The app's reactive scope.
     pub cx: Scope<'a>,
+    /// The `Signal` for the current view, which will imperatively set by the
+    /// user's template function (due to the use of child scopes).
+    pub curr_view: &'a Signal<View<TemplateNodeType>>,
+    /// The scope disposers for pages, which will be dumped as necessary.
+    ///
+    /// Note that error pages are rendered on the app-level scope, so we don't
+    /// have to worry about them with these.
+    pub scope_disposers: &'a Signal<Vec<ScopeDisposer<'a>>>,
     /// The path we're rendering for (not the template path, the full path,
     /// though parsed a little).
     pub path: String,
@@ -44,13 +52,15 @@ pub(crate) struct GetSubsequentViewProps<'a> {
 pub(crate) async fn get_subsequent_view(
     GetSubsequentViewProps {
         cx,
+        curr_view,
+        scope_disposers,
         path,
         template,
         was_incremental_match,
         locale,
         route_verdict,
     }: GetSubsequentViewProps<'_>,
-) -> View<TemplateNodeType> {
+) -> SubsequentView {
     let render_ctx = RenderCtx::from_ctx(cx);
     let router_state = &render_ctx.router;
     let translations_manager = &render_ctx.translations_manager;
@@ -187,7 +197,7 @@ pub(crate) async fn get_subsequent_view(
     // Any errors will be prepared error pages ready for return
     let page_data = match page_data {
         Ok(page_data) => page_data,
-        Err(view) => return view,
+        Err(view) => return SubsequentView::Error(view),
     };
 
     // Interpolate the metadata directly into the document's `<head>`
@@ -208,35 +218,41 @@ pub(crate) async fn get_subsequent_view(
                 // These errors happen because we couldn't get a translator, so they certainly don't
                 // get one
                 ClientError::FetchError(FetchError::NotOk { url, status, .. }) => {
-                    return error_pages.get_view_and_render_head(
+                    return SubsequentView::Error(error_pages.get_view_and_render_head(
                         cx,
                         url,
                         *status,
                         &fmt_err(&err),
                         None,
-                    )
+                    ))
                 }
                 ClientError::FetchError(FetchError::SerFailed { url, .. }) => {
-                    return error_pages.get_view_and_render_head(cx, url, 500, &fmt_err(&err), None)
+                    return SubsequentView::Error(error_pages.get_view_and_render_head(
+                        cx,
+                        url,
+                        500,
+                        &fmt_err(&err),
+                        None,
+                    ))
                 }
                 ClientError::LocaleNotSupported { locale } => {
-                    return error_pages.get_view_and_render_head(
+                    return SubsequentView::Error(error_pages.get_view_and_render_head(
                         cx,
                         &format!("/{}/...", locale),
                         404,
                         &fmt_err(&err),
                         None,
-                    )
+                    ))
                 }
                 // No other errors should be returned, but we'll give any a 400
                 _ => {
-                    return error_pages.get_view_and_render_head(
+                    return SubsequentView::Error(error_pages.get_view_and_render_head(
                         cx,
                         &format!("/{}/...", locale),
                         400,
                         &fmt_err(&err),
                         None,
-                    )
+                    ))
                 }
             }
         }
@@ -255,5 +271,13 @@ pub(crate) async fn get_subsequent_view(
         path: path_with_locale,
     });
     // Now return the view that should be rendered
-    template.render_for_template_client(page_props, cx, translator)
+    template.render_for_template_client(page_props, cx, curr_view, scope_disposers, translator);
+    SubsequentView::Success
+}
+
+pub(crate) enum SubsequentView {
+    /// The page view *has been* rendered *and* displayed.
+    Success,
+    /// An error view was rendered, and shoudl now be displayed.
+    Error(View<TemplateNodeType>),
 }

--- a/packages/perseus/src/router/get_subsequent_view.rs
+++ b/packages/perseus/src/router/get_subsequent_view.rs
@@ -17,11 +17,11 @@ pub(crate) struct GetSubsequentViewProps<'a> {
     /// The `Signal` for the current view, which will imperatively set by the
     /// user's template function (due to the use of child scopes).
     pub curr_view: &'a Signal<View<TemplateNodeType>>,
-    /// The scope disposers for pages, which will be dumped as necessary.
+    /// The scope disposer for pages, which will be dumped as necessary.
     ///
     /// Note that error pages are rendered on the app-level scope, so we don't
-    /// have to worry about them with these.
-    pub scope_disposers: &'a Signal<Vec<ScopeDisposer<'a>>>,
+    /// have to worry about them with this.
+    pub scope_disposers: PageDisposer<'a>,
     /// The path we're rendering for (not the template path, the full path,
     /// though parsed a little).
     pub path: String,

--- a/packages/perseus/src/router/mod.rs
+++ b/packages/perseus/src/router/mod.rs
@@ -23,4 +23,4 @@ pub use router_state::{RouterLoadState, RouterState};
 #[cfg(target_arch = "wasm32")]
 pub(crate) use get_initial_view::{get_initial_view, InitialView};
 #[cfg(target_arch = "wasm32")]
-pub(crate) use get_subsequent_view::{get_subsequent_view, GetSubsequentViewProps};
+pub(crate) use get_subsequent_view::{get_subsequent_view, GetSubsequentViewProps, SubsequentView};

--- a/packages/perseus/src/router/mod.rs
+++ b/packages/perseus/src/router/mod.rs
@@ -6,11 +6,11 @@ mod get_initial_view;
 mod get_subsequent_view;
 mod match_route;
 mod page_disposer;
+mod route_manager;
 mod route_verdict;
 #[cfg(target_arch = "wasm32")]
 mod router_component;
 mod router_state;
-mod route_manager;
 
 #[cfg(target_arch = "wasm32")]
 pub(crate) use app_route::PerseusRoute;

--- a/packages/perseus/src/router/mod.rs
+++ b/packages/perseus/src/router/mod.rs
@@ -10,6 +10,7 @@ mod route_verdict;
 #[cfg(target_arch = "wasm32")]
 mod router_component;
 mod router_state;
+mod route_manager;
 
 #[cfg(target_arch = "wasm32")]
 pub(crate) use app_route::PerseusRoute;
@@ -27,3 +28,4 @@ pub(crate) use get_initial_view::{get_initial_view, InitialView};
 pub(crate) use get_subsequent_view::{get_subsequent_view, GetSubsequentViewProps, SubsequentView};
 
 pub use page_disposer::PageDisposer;
+pub use route_manager::RouteManager;

--- a/packages/perseus/src/router/mod.rs
+++ b/packages/perseus/src/router/mod.rs
@@ -5,6 +5,7 @@ mod get_initial_view;
 #[cfg(target_arch = "wasm32")]
 mod get_subsequent_view;
 mod match_route;
+mod page_disposer;
 mod route_verdict;
 #[cfg(target_arch = "wasm32")]
 mod router_component;
@@ -24,3 +25,5 @@ pub use router_state::{RouterLoadState, RouterState};
 pub(crate) use get_initial_view::{get_initial_view, InitialView};
 #[cfg(target_arch = "wasm32")]
 pub(crate) use get_subsequent_view::{get_subsequent_view, GetSubsequentViewProps, SubsequentView};
+
+pub use page_disposer::PageDisposer;

--- a/packages/perseus/src/router/page_disposer.rs
+++ b/packages/perseus/src/router/page_disposer.rs
@@ -1,0 +1,51 @@
+use std::rc::Rc;
+
+use sycamore::{
+    prelude::{create_signal, Scope, Signal},
+    reactive::ScopeDisposer,
+};
+
+/// This stores the disposers for user pages so that they can be safely
+/// unmounted when the view changes.
+///
+/// If you're using the `#[template]` macro and the like, you will never need to
+/// use this. If you're not using the macros for some reason, you shoudl consult
+/// their code to make sure you use this correctly.
+#[derive(Clone, Copy)]
+pub struct PageDisposer<'a> {
+    /// The underlying `ScopeDisposer`. This will initially be `None` before any
+    /// views have been rendered.
+    ///
+    /// There is no way to get this underlying scope disposer, it can only be
+    /// set. Hence, we prevent there ever being multiple references to the
+    /// underlying `Signal`.
+    disposer: &'a Signal<Option<ScopeDisposer<'a>>>,
+}
+impl<'a> PageDisposer<'a> {
+    /// Creates a new `PageDisposer` in the given app scope.
+    pub(crate) fn new(cx: Scope<'a>) -> Self {
+        Self {
+            disposer: create_signal(cx, None),
+        }
+    }
+    /// Updates the undelrying data structure to hold the given disposer, taking
+    /// any previous disposer and disposing it.
+    ///
+    /// # Safety
+    /// This must not be called inside the scope in which the previous disposer
+    /// was created.
+    pub fn update(&self, new_disposer: ScopeDisposer<'a>) {
+        // Dispose of any old disposers
+        if self.disposer.get().is_some() {
+            let old_disposer_rc = self.disposer.take();
+            let old_disposer_option = Rc::try_unwrap(old_disposer_rc).unwrap(); // See docs on `disposer` field
+            let old_disposer = old_disposer_option.unwrap(); // We're in a conditional that checked this
+
+            // SAFETY: This function is documented to be only called when we're not inside
+            // the same scope as we're disposing of
+            unsafe { old_disposer.dispose() };
+        }
+
+        self.disposer.set(Some(new_disposer));
+    }
+}

--- a/packages/perseus/src/router/route_manager.rs
+++ b/packages/perseus/src/router/route_manager.rs
@@ -1,36 +1,47 @@
 use super::PageDisposer;
-use sycamore::{prelude::{Scope, ScopeDisposer, Signal, View, create_signal}, web::Html};
+use sycamore::{
+    prelude::{create_signal, Scope, ScopeDisposer, Signal, View},
+    web::Html,
+};
 
-/// The internals that allow Perseus to manage the many routes of an app, including
-/// child scope disposal. This should almost never be interacted with by end users!
+/// The internals that allow Perseus to manage the many routes of an app,
+/// including child scope disposal. This should almost never be interacted with
+/// by end users!
 ///
-/// This takes the lifetime of the whole app's root scope. Note that this is not put
-/// in `RenderCtx`, since it should not be accessible except through raw templates.
+/// This takes the lifetime of the whole app's root scope. Note that this is not
+/// put in `RenderCtx`, since it should not be accessible except through raw
+/// templates.
 ///
-/// Note that this is used instead of the component parts to ensure lifetime sameness.
+/// Note that this is used instead of the component parts to ensure lifetime
+/// sameness.
 #[derive(Clone)]
 pub struct RouteManager<'cx, G: Html> {
     page_disposer: PageDisposer<'cx>,
     // We occasionally need to `.get()` and `.take()` this
     pub(crate) view: &'cx Signal<View<G>>,
 }
-// We don't allow direct field access to minimize the likelihood to users shooting themselves in the foot (or, in this case, kidney)
+// We don't allow direct field access to minimize the likelihood to users
+// shooting themselves in the foot (or, in this case, kidney)
 impl<'cx, G: Html> RouteManager<'cx, G> {
-    /// Creates a new route manager, with an empty view and no scopes to dispose of yet.
+    /// Creates a new route manager, with an empty view and no scopes to dispose
+    /// of yet.
     pub(crate) fn new(cx: Scope<'cx>) -> Self {
         Self {
             page_disposer: PageDisposer::new(cx),
             view: create_signal(cx, View::empty()),
         }
     }
-    /// Updates the current view of the app. The argument here will be rendered to the root of the app.
+    /// Updates the current view of the app. The argument here will be rendered
+    /// to the root of the app.
     ///
-    /// This should NEVER be invoked outside the typical lifecycle of Perseus routing! If you want to render
-    /// and error page or the like, use that API, not this one!
+    /// This should NEVER be invoked outside the typical lifecycle of Perseus
+    /// routing! If you want to render and error page or the like, use that
+    /// API, not this one!
     pub fn update_view(&self, new_view: View<G>) {
         self.view.set(new_view);
     }
-    /// Updates the underlying scope disposer. See the docs for [`PageDisposer`] for more information.
+    /// Updates the underlying scope disposer. See the docs for [`PageDisposer`]
+    /// for more information.
     pub fn update_disposer(&mut self, new_disposer: ScopeDisposer<'cx>) {
         self.page_disposer.update(new_disposer);
     }

--- a/packages/perseus/src/router/route_manager.rs
+++ b/packages/perseus/src/router/route_manager.rs
@@ -1,0 +1,37 @@
+use super::PageDisposer;
+use sycamore::{prelude::{Scope, ScopeDisposer, Signal, View, create_signal}, web::Html};
+
+/// The internals that allow Perseus to manage the many routes of an app, including
+/// child scope disposal. This should almost never be interacted with by end users!
+///
+/// This takes the lifetime of the whole app's root scope. Note that this is not put
+/// in `RenderCtx`, since it should not be accessible except through raw templates.
+///
+/// Note that this is used instead of the component parts to ensure lifetime sameness.
+#[derive(Clone)]
+pub struct RouteManager<'cx, G: Html> {
+    page_disposer: PageDisposer<'cx>,
+    // We occasionally need to `.get()` and `.take()` this
+    pub(crate) view: &'cx Signal<View<G>>,
+}
+// We don't allow direct field access to minimize the likelihood to users shooting themselves in the foot (or, in this case, kidney)
+impl<'cx, G: Html> RouteManager<'cx, G> {
+    /// Creates a new route manager, with an empty view and no scopes to dispose of yet.
+    pub(crate) fn new(cx: Scope<'cx>) -> Self {
+        Self {
+            page_disposer: PageDisposer::new(cx),
+            view: create_signal(cx, View::empty()),
+        }
+    }
+    /// Updates the current view of the app. The argument here will be rendered to the root of the app.
+    ///
+    /// This should NEVER be invoked outside the typical lifecycle of Perseus routing! If you want to render
+    /// and error page or the like, use that API, not this one!
+    pub fn update_view(&self, new_view: View<G>) {
+        self.view.set(new_view);
+    }
+    /// Updates the underlying scope disposer. See the docs for [`PageDisposer`] for more information.
+    pub fn update_disposer(&mut self, new_disposer: ScopeDisposer<'cx>) {
+        self.page_disposer.update(new_disposer);
+    }
+}

--- a/packages/perseus/src/router/router_component.rs
+++ b/packages/perseus/src/router/router_component.rs
@@ -6,7 +6,7 @@ use crate::{
         get_initial_view, get_subsequent_view, GetSubsequentViewProps, InitialView,
         RouterLoadState, SubsequentView,
     },
-    router::{RouteManager, PerseusRoute, RouteInfo, RouteVerdict},
+    router::{PerseusRoute, RouteInfo, RouteManager, RouteVerdict},
     template::{RenderCtx, TemplateMap, TemplateNodeType},
     utils::get_path_prefix_client,
     ErrorPages,
@@ -15,8 +15,8 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use sycamore::{
     prelude::{
-        component, create_effect, create_signal, on_mount, view, ReadSignal, Scope,
-        View, create_ref,
+        component, create_effect, create_ref, create_signal, on_mount, view, ReadSignal, Scope,
+        View,
     },
     Prop,
 };

--- a/packages/perseus/src/router/router_component.rs
+++ b/packages/perseus/src/router/router_component.rs
@@ -3,7 +3,8 @@ use crate::{
     i18n::detect_locale,
     i18n::Locales,
     router::{
-        get_initial_view, get_subsequent_view, GetSubsequentViewProps, InitialView, RouterLoadState,
+        get_initial_view, get_subsequent_view, GetSubsequentViewProps, InitialView,
+        RouterLoadState, SubsequentView,
     },
     router::{PerseusRoute, RouteInfo, RouteVerdict},
     template::{RenderCtx, TemplateMap, TemplateNodeType},
@@ -14,7 +15,8 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use sycamore::{
     prelude::{
-        component, create_effect, create_signal, on_mount, view, ReadSignal, Scope, Signal, View,
+        component, create_effect, create_signal, on_mount, view, ReadSignal, Scope, ScopeDisposer,
+        Signal, View,
     },
     Prop,
 };
@@ -39,9 +41,9 @@ const ROUTE_ANNOUNCER_STYLES: &str = r#"
 "#;
 
 /// Get the view we should be rendering at the moment, based on a route verdict.
-/// This should be called on every route change to update the page. This doesn't
-/// actually render the view, it just returns it for rendering. Note that this
-/// may return error pages.
+/// This should be called on every route change to update the page. This will
+/// return the view it returns, and may add to the scope disposers. Note that
+/// this may return error pages.
 ///
 /// This function is designed for managing subsequent views only, since the
 /// router component should be instantiated *after* the initial view
@@ -49,10 +51,12 @@ const ROUTE_ANNOUNCER_STYLES: &str = r#"
 ///
 /// If the page needs to redirect to a particular locale, then this function
 /// will imperatively do so.
-async fn get_view(
-    cx: Scope<'_>,
+async fn set_view<'a>(
+    cx: Scope<'a>,
+    curr_view: &'a Signal<View<TemplateNodeType>>,
+    scope_disposers: &'a Signal<Vec<ScopeDisposer<'a>>>,
     verdict: RouteVerdict<TemplateNodeType>,
-) -> View<TemplateNodeType> {
+) {
     checkpoint("router_entry");
     match &verdict {
         RouteVerdict::Found(RouteInfo {
@@ -61,15 +65,21 @@ async fn get_view(
             locale,
             was_incremental_match,
         }) => {
-            get_subsequent_view(GetSubsequentViewProps {
+            let subsequent_view = get_subsequent_view(GetSubsequentViewProps {
                 cx,
+                curr_view,
+                scope_disposers,
                 path: path.clone(),
                 template: template.clone(),
                 was_incremental_match: *was_incremental_match,
                 locale: locale.clone(),
                 route_verdict: verdict,
             })
-            .await
+            .await;
+            // Display any errors now
+            if let SubsequentView::Error(view) = subsequent_view {
+                curr_view.set(view);
+            }
         }
         // For subsequent loads, this should only be possible if the dev forgot `link!()`
         RouteVerdict::LocaleDetection(path) => {
@@ -79,16 +89,19 @@ async fn get_view(
             // This shouldn't be a replacement navigation, since the user has deliberately
             // navigated here
             sycamore_router::navigate(&dest);
-            View::empty()
         }
         RouteVerdict::NotFound => {
             let render_ctx = RenderCtx::from_ctx(cx);
             checkpoint("not_found");
             // TODO Update the router state here (we need a path though...)
             // This function only handles subsequent loads, so this is all we have
-            render_ctx
-                .error_pages
-                .get_view_and_render_head(cx, "", 404, "not found", None)
+            curr_view.set(render_ctx.error_pages.get_view_and_render_head(
+                cx,
+                "",
+                404,
+                "not found",
+                None,
+            ))
         }
     }
 }
@@ -142,6 +155,10 @@ pub(crate) fn perseus_router(
     )
     .set_ctx(cx);
 
+    // Create the two signals that handle routing in Perseus
+    let curr_view = create_signal(cx, View::empty());
+    let scope_disposers = create_signal(cx, Vec::new()); // For disposing of the child scopes for pages
+
     // Get the current path, removing any base paths to avoid relative path locale
     // redirection loops (in previous versions of Perseus, we used Sycamore to
     // get the path, and it strips this out automatically)
@@ -157,25 +174,22 @@ pub(crate) fn perseus_router(
     };
     // Prepare the initial view for hydration (because we have everything we need in
     // global window variables, this can be synchronous)
-    let initial_view = get_initial_view(cx, path.to_string());
-    let initial_view = match initial_view {
-        InitialView::View(initial_view) => initial_view,
-        // if we need to redirect, then we'll create a fake view that will just execute that code
+    let initial_view = get_initial_view(cx, path.to_string(), curr_view, scope_disposers);
+    match initial_view {
+        // Any errors are simply returned, it's our responsibility to display them
+        InitialView::Error(view) => curr_view.set(view),
+        // If we need to redirect, then we'll create a fake view that will just execute that code
         // (which we can guarantee to run after the router is ready)
         InitialView::Redirect(dest) => {
             let dest = dest.clone();
             on_mount(cx, move || {
                 sycamore_router::navigate_replace(&dest);
             });
-            // Note that using an empty view doesn't lead to any layout shift, since
-            // redirects have nothing rendered on the server-side (so this is actually
-            // correct hydration)
-            View::empty()
         }
+        // A successful render has already been displayed to `curr_view`
+        InitialView::Success => (),
     };
-    // Define a `Signal` for the view we're going to be currently rendering, which
-    // will contain the current page, or some kind of error message
-    let curr_view: &Signal<View<TemplateNodeType>> = create_signal(cx, initial_view);
+
     // This allows us to not run the subsequent load code on the initial load (we
     // need a separate one for the reload commander)
     let is_initial = create_signal(cx, true);
@@ -264,8 +278,7 @@ pub(crate) fn perseus_router(
                 None => return,
             };
             spawn_local_scoped(cx, async move {
-                let new_view = get_view(cx, verdict.clone()).await;
-                curr_view.set(new_view);
+                set_view(cx, curr_view, scope_disposers, verdict.clone()).await;
             });
         }
     });
@@ -354,8 +367,7 @@ pub(crate) fn perseus_router(
                         spawn_local_scoped(cx, async move {
                             let route = route.get();
                             let verdict = route.get_verdict();
-                            let new_view = get_view(cx, verdict.clone()).await;
-                            curr_view.set(new_view);
+                            set_view(cx, curr_view, scope_disposers, verdict.clone()).await;
                         });
                     }
                 });


### PR DESCRIPTION
Right now, Perseus renders all user pages under the single, global `cx` scope, which is used for the entire app. This works well, until you use something like the router state (a global entity) and log every time there's a page change. I tried this in my rebuild of my own blog, and found very quickly that the logs were accumulating: the listeners were not being killed when I was navigating off the page. In other words, all listeners on global events were accumulating in Perseus apps. This may have been the cause of the error I occasionally observed while working on the Perseus website for long stretches, whereby my browser would freeze up after a few hours until I killed the tab. I now believe that *may* have been due to listener accumulations and improper memory clearing.

This PR adds a `RouteManager` `struct` to Perseus, which bundles together a `Signal` registered on the app scope for storing the current `View<G>` with a `ScopeDisposer` for the current view's scope. All user pages are rendered in a child scope (created by the `#[template]` macro, for now), and, when a new page is rendered, the old view is replaced, and the old scope disposer is disposed of. This introduces a single line of `unsafe` to the Perseus core, with safety clearly enforced by the macros. (Users who avoid `#[template]` should be cautious not to dispose of a scope inside that scope, which is pretty much common sense, and very clearly documented.) This entirely prevents the issues explained above.