### PR TITLE
Add Tailwind plugin to plugin directory

### DIFF
--- a/website/plugins/en-US/tailwind.json
+++ b/website/plugins/en-US/tailwind.json
@@ -1,0 +1,7 @@
+{
+  "name": "Tailwind Plugin",
+  "description": "Automatically builds Tailwind CSS during your build process.",
+  "author": "wingertge",
+  "url": "https://github.com/wingertge/perseus-tailwind",
+  "trusted": false
+}


### PR DESCRIPTION
This adds the Tailwind Plugin I wrote to the plugin directory. It downloads and initializes the Tailwind standalone CLI and then compiles the Tailwind CSS at build time. All platforms that have a binary available are supported (Linux x64/arm, macOS x64/arm, Windows x64).