### PR TITLE
chore: added target to generated gitignore

### DIFF
--- a/packages/perseus-cli/src/init.rs
+++ b/packages/perseus-cli/src/init.rs
@@ -141,7 +141,8 @@ perseus-axum = { version = "=%perseus_version", features = [ "dflt-server" ] }
 
 # Browser-only dependencies go here
 [target.'cfg(client)'.dependencies]"#;
-static DFLT_INIT_GITIGNORE: &str = r#"dist/"#;
+static DFLT_INIT_GITIGNORE: &str = r#"dist/
+target/"#;
 static DFLT_INIT_MAIN_RS: &str = r#"mod templates;
 
 use perseus::prelude::*;


### PR DESCRIPTION
hey :)

just a minimal change as a start as we will always wish to add the `target` folder to the `.gitignore`. 