### PR TITLE
Could not build a --release perseus app in beta.19

### DIFF
--- a/packages/perseus/src/reactor/global_state.rs
+++ b/packages/perseus/src/reactor/global_state.rs
@@ -175,6 +175,7 @@ impl<G: Html> Reactor<G> {
 
             // If this is an HSR thaw, and this type is to be ignored from HSR, then ignore
             // it
+            #[cfg(debug_assertions)]
             if *is_hsr && S::HSR_IGNORE {
                 return Ok(None);
             }

--- a/packages/perseus/src/reactor/state.rs
+++ b/packages/perseus/src/reactor/state.rs
@@ -407,6 +407,7 @@ impl<G: Html> Reactor<G> {
 
             // If this is an HSR thaw, and this type is to be ignored from HSR, then ignore
             // it
+            #[cfg(debug_assertions)]
             if *is_hsr && S::HSR_IGNORE {
                 return Ok(None);
             }


### PR DESCRIPTION
This fixes #259

I could not run all tests, lots of building for a long time that ended abruptly with an unknown command `rust-script`. Hopefully the CI can  give a better feedback on this than I could.

Since HSR is a development feature (right?), I just "wrapped" the problematic if conditions inside the debug guard. Let me know if that was not the right solution.

