### PR TITLE
Support `anyhow::Error` in state generation functions

### DIFF
--- a/examples/core/state_generation/Cargo.toml
+++ b/examples/core/state_generation/Cargo.toml
@@ -10,6 +10,7 @@ perseus = { path = "../../../packages/perseus", features = [ "hydrate" ] }
 sycamore = "^0.8.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+anyhow = "1"
 
 [dev-dependencies]
 fantoccini = "0.17"

--- a/examples/core/state_generation/src/templates/incremental_generation.rs
+++ b/examples/core/state_generation/src/templates/incremental_generation.rs
@@ -48,7 +48,7 @@ pub fn get_template<G: Html>() -> Template<G> {
 #[engine_only_fn]
 async fn get_build_state(
     StateGeneratorInfo { path, .. }: StateGeneratorInfo<()>,
-) -> Result<PageState, BlamedError<std::io::Error>> {
+) -> Result<PageState, BlamedError<anyhow::Error>> {
     // This path is illegal, and can't be rendered
     // Because we're using incremental generation, we could get literally anything
     // as the `path`
@@ -56,14 +56,13 @@ async fn get_build_state(
         // This tells Perseus to return an error that's the client's fault, with the
         // HTTP status code 404 (not found) and the message 'illegal page'. Note that
         // this is a `BlamedError<std::io::Error>`, but we could use any error type that
-        // implements `std::error::Error` (note that this does make `anyhow` a
-        // bit tricky, if you use it).
+        // implements `std::error::Error` or can be converted into a boxed `std::error::Error`.
         return Err(BlamedError {
             // If we used `None` instead, it would default to 400 for the client and 500 for the
             // server
             blame: ErrorBlame::Client(Some(404)),
             // This is just an example, and you could put any error type here, usually your own
-            error: std::io::Error::new(std::io::ErrorKind::NotFound, "illegal page"),
+            error: anyhow::anyhow!("illegal page"),
         });
     }
     let title = path.clone();

--- a/packages/perseus/src/errors.rs
+++ b/packages/perseus/src/errors.rs
@@ -491,12 +491,12 @@ pub struct BlamedError<E: Send + Sync> {
     pub blame: ErrorBlame,
 }
 #[cfg(engine)]
-impl<E: std::error::Error + Send + Sync + 'static> BlamedError<E> {
+impl<E: Into<Box<dyn std::error::Error + Send + Sync + 'static>> + Send + Sync> BlamedError<E> {
     /// Converts this blamed error into an internal boxed version that is
     /// generic over the error type.
     pub(crate) fn into_boxed(self) -> GenericBlamedError {
         BlamedError {
-            error: Box::new(self.error),
+            error: self.error.into(),
             blame: self.blame,
         }
     }

--- a/packages/perseus/src/errors.rs
+++ b/packages/perseus/src/errors.rs
@@ -504,7 +504,9 @@ impl<E: Into<Box<dyn std::error::Error + Send + Sync + 'static>> + Send + Sync> 
 // We should be able to convert any error into this easily (e.g. with `?`) with
 // the default being to blame the server
 #[cfg(engine)]
-impl<E: std::error::Error + Send + Sync + 'static> From<E> for BlamedError<E> {
+impl<E: Into<Box<dyn std::error::Error + Send + Sync + 'static>> + Send + Sync> From<E>
+    for BlamedError<E>
+{
     fn from(error: E) -> Self {
         Self {
             error,

--- a/packages/perseus/src/template/fn_types.rs
+++ b/packages/perseus/src/template/fn_types.rs
@@ -172,8 +172,10 @@ impl<S: Serialize + DeserializeOwned + MakeRx> From<S> for BlamedGeneratorResult
         Self::Ok(val)
     }
 }
-impl<S: Serialize + DeserializeOwned + MakeRx, E: std::error::Error + Send + Sync + 'static>
-    From<Result<S, BlamedError<E>>> for BlamedGeneratorResult<S>
+impl<
+        S: Serialize + DeserializeOwned + MakeRx,
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>> + Send + Sync,
+    > From<Result<S, BlamedError<E>>> for BlamedGeneratorResult<S>
 {
     fn from(val: Result<S, BlamedError<E>>) -> Self {
         match val {
@@ -188,8 +190,8 @@ impl From<bool> for BlamedGeneratorResult<bool> {
         Self::Ok(val)
     }
 }
-impl<E: std::error::Error + Send + Sync + 'static> From<Result<bool, BlamedError<E>>>
-    for BlamedGeneratorResult<bool>
+impl<E: Into<Box<dyn std::error::Error + Send + Sync + 'static>> + Send + Sync>
+    From<Result<bool, BlamedError<E>>> for BlamedGeneratorResult<bool>
 {
     fn from(val: Result<bool, BlamedError<E>>) -> Self {
         match val {


### PR DESCRIPTION
By generalizing the supported errors in state generation from types that directly implement `std::error::Error` to types that can be converted into a boxed `std::error::Error`, we can make `anyhow::Error` work.

I first tried to support just `anyhow::Error` specifically (in addition to the already-supported error types), but the compiler does not easily allow that: it thinks `anyhow::Error` might implement `std::error::Error` in the future, so it will not let me implement things on both. Please make sure the broader support for error types this adds is reasonable (and that I am correct about this change being backwards-compatible) before merging.