### PR TITLE
Added feature flag for standard wasm build

### DIFF
--- a/packages/perseus/Cargo.toml
+++ b/packages/perseus/Cargo.toml
@@ -52,7 +52,7 @@ wasm-bindgen-futures = "0.4"
 [features]
 # Live reloading will only take effect in development, and won't impact production
 # BUG This adds 1.9kB to the production bundle (that's without size optimizations though)
-default = [ "live-reload", "hsr", "client-helpers", "macros", "dflt-engine", "minify", "minify-css", "cache-initial-load" ]
+default = [ "live-reload", "hsr", "client-helpers", "macros", "dflt-engine", "minify", "minify-css", "cache-initial-load", "wasm-standard" ]
 translator-fluent = ["fluent-bundle", "unic-langid", "intl-memoizer"]
 translator-lightweight = []
 # Suspends all `click` events at the document root until Perseus is fully loaded, then passing them through.
@@ -80,6 +80,8 @@ hydrate = []
 preload-wasm-on-redirect = []
 # This exposes an API for saving frozen state to IndexedDB simply, with options for making your storage persistent so the browser won't delete it
 idb-freezing = [ "rexie", "web-sys/StorageManager" ]
+# Switches to expecting the server to provide a Wasm bundle
+wasm-standard = []
 # Switches to expecting the server to provide a JS bundle that's been created from Wasm
 # Note that this is highly experimental, and currently blocked by [rustwasm/wasm-bindgen#2735](https://github.com/rustwasm/wasm-bindgen/issues/2735)
 # This is *deliberately* undocumented in `lib.rs`!

--- a/packages/perseus/src/server/html_shell.rs
+++ b/packages/perseus/src/server/html_shell.rs
@@ -127,7 +127,10 @@ impl HtmlShell {
         //
         // Note: because we're using binary bundles, we don't need to import
         // a `main` function or the like, `init()` just works
-        #[cfg(not(feature = "wasm2js"))]
+        #[cfg(all(feature = "wasm2js", feature = "wasm-standard"))]
+        compile_error!("feature \"wasm2js\" and feature \"wasm-standard\" cannot be enabled at the same time");
+        
+        #[cfg(feature = "wasm-standard")]
         let load_wasm_bundle = format!(
             r#"
         import init from "{path_prefix}/.perseus/bundle.js";


### PR DESCRIPTION
Named the feature wasm-standard 
Instead of using not wasm2js. Set it default feature as standard.
Useful as we can disable this and then you can load your wasm file in your own way.