### PR TITLE
Allow for customization of path_prefix_server by setting Turbine field.

### DIFF
--- a/packages/perseus/src/init.rs
+++ b/packages/perseus/src/init.rs
@@ -1,7 +1,5 @@
 #[cfg(engine)]
 use crate::server::HtmlShell;
-#[cfg(engine)]
-use crate::utils::get_path_prefix_server;
 use crate::{
     error_views::ErrorViews,
     i18n::{Locales, TranslationsManager},
@@ -824,10 +822,10 @@ impl<G: Html, M: MutableStore, T: TranslationsManager> PerseusAppBase<G, M, T> {
         root: &str,
         render_cfg: &HashMap<String, String>,
         plugins: &Plugins,
+        path_prefix_server: &str,
     ) -> Result<HtmlShell, PluginError> {
         // Construct an HTML shell
-        let mut html_shell =
-            HtmlShell::new(index_view_str, root, render_cfg, &get_path_prefix_server());
+        let mut html_shell = HtmlShell::new(index_view_str, root, render_cfg, path_prefix_server);
 
         // Apply the myriad plugin actions to the HTML shell (replacing the whole thing
         // first if need be)

--- a/packages/perseus/src/turbine/build.rs
+++ b/packages/perseus/src/turbine/build.rs
@@ -111,6 +111,7 @@ impl<M: MutableStore, T: TranslationsManager> Turbine<M, T> {
             &self.root_id,
             &self.render_cfg,
             &self.plugins,
+            self.get_path_prefix_server().as_ref(),
         )
         .await?;
         self.html_shell = Some(html_shell);

--- a/packages/perseus/src/turbine/export.rs
+++ b/packages/perseus/src/turbine/export.rs
@@ -7,7 +7,6 @@ use crate::{
     plugins::PluginAction,
     state::TemplateState,
     stores::MutableStore,
-    utils::get_path_prefix_server,
 };
 use fs_extra::dir::{copy as copy_dir, CopyOptions};
 use futures::future::{try_join, try_join_all};
@@ -105,7 +104,7 @@ impl<M: MutableStore, T: TranslationsManager> Turbine<M, T> {
         // We assume we've already built the app, which would have populated this
         let html_shell = self.html_shell.as_ref().unwrap();
 
-        let path_prefix = get_path_prefix_server();
+        let path_prefix = self.get_path_prefix_server();
         // We need the encoded path to reference flattened build artifacts
         // But we don't create a flattened system with exporting, everything is properly
         // created in a directory structure

--- a/packages/perseus/src/turbine/server.rs
+++ b/packages/perseus/src/turbine/server.rs
@@ -8,7 +8,6 @@ use crate::{
     server::get_path_slice,
     state::TemplateState,
     stores::MutableStore,
-    utils::get_path_prefix_server,
     Request,
 };
 use fmterr::fmt_err;
@@ -309,7 +308,7 @@ impl<M: MutableStore, T: TranslationsManager> Turbine<M, T> {
                         // bundle will do.
                         &format!(
                             "{}/{}/{}",
-                            get_path_prefix_server(),
+                            self.get_path_prefix_server(),
                             &self.locales.default,
                             // This is a `PathWithoutLocale`
                             redirect_path.0,

--- a/packages/perseus/src/utils/path_prefix.rs
+++ b/packages/perseus/src/utils/path_prefix.rs
@@ -1,19 +1,3 @@
-/// Gets the path prefix to apply on the server. This uses the
-/// `PERSEUS_BASE_PATH` environment variable, which avoids hardcoding
-/// something as changeable as this into the final binary. Hence however, that
-/// variable must be the same as what's set in `<base>` (done automatically).
-/// Trailing forward slashes will be trimmed automatically.
-#[cfg(engine)]
-pub fn get_path_prefix_server() -> String {
-    use std::env;
-
-    let base_path = env::var("PERSEUS_BASE_PATH").unwrap_or_else(|_| "".to_string());
-    base_path
-        .strip_suffix('/')
-        .unwrap_or(&base_path)
-        .to_string()
-}
-
 /// Gets the path prefix to apply in the browser. This uses the HTML `<base>`
 /// element, which would be required anyway to make Sycamore's router co-operate
 /// with a relative path hosting.


### PR DESCRIPTION
Currently only a single Perseus app can be served by a single server backend. While Perseus already allows for customization of app base path, this customization is activated by setting PERSEUS_BASE_PATH environment variable, which means that the same path prefix is applied process-wide, so it's not possible to create a non-standard server implementation "mounting" two Turbines on different URL mountpoints.
This means that the only way to have multiple Perseus apps running under the same origin is to use a reverse proxy to forward requests to different Perseus servers.
This PR is meant to allow setting a path_prefix_server on a Turbine, while leaving the default behavior of resolving PERSEUS_BASE_PATH environment variable if a custom value is not set.