### PR TITLE
Switch to JS for defining internal constants

### DIFF
--- a/packages/perseus-actix-web/src/lib.rs
+++ b/packages/perseus-actix-web/src/lib.rs
@@ -95,6 +95,19 @@ pub async fn configurer<M: MutableStore + 'static, T: TranslationsManager + 'sta
                 }),
             )
             .route(
+                "/.perseus/initial_consts/{locale}.js",
+                web::get().to(move |http_req: HttpRequest| async move {
+                    let locale = http_req.match_info().query("locale");
+                    ApiResponse(turbine.get_initial_consts(locale).await)
+                })
+            )
+            .route(
+                "/.perseus/initial_consts.js",
+                web::get().to(move || async move {
+                    ApiResponse(turbine.get_initial_consts("").await)
+                })
+            )
+            .route(
                 // We capture the `.json` ending in the handler
                 "/.perseus/page/{locale}/{filename:.*}",
                 web::get().to(move |http_req: HttpRequest, web::Query(query_params): web::Query<SubsequentLoadQueryParams>| async move {

--- a/packages/perseus-axum/src/lib.rs
+++ b/packages/perseus-axum/src/lib.rs
@@ -84,6 +84,16 @@ pub async fn get_router<M: MutableStore + 'static, T: TranslationsManager + 'sta
             }),
         )
         .route(
+            "/.perseus/initial_consts.js",
+            get(move || async move { ApiResponse(turbine.get_initial_consts("").await) }),
+        )
+        .route(
+            "/.perseus/initial_consts/:locale.js",
+            get(move |Path(locale): Path<String>| async move {
+                ApiResponse(turbine.get_initial_consts(&locale).await)
+            }),
+        )
+        .route(
             "/.perseus/page/:locale/*tail",
             get(
                 move |Path(path_parts): Path<Vec<String>>,

--- a/packages/perseus-axum/src/lib.rs
+++ b/packages/perseus-axum/src/lib.rs
@@ -92,7 +92,12 @@ pub async fn get_router<M: MutableStore + 'static, T: TranslationsManager + 'sta
             get(move |Path(locale): Path<String>| async move {
                 let locale = match locale.strip_suffix(".js") {
                     Some(locale) => locale,
-                    None => return ApiResponse(PerseusApiResponse::err(StatusCode::BAD_REQUEST, "invalid locale (needs `.js` extension)")),
+                    None => {
+                        return ApiResponse(PerseusApiResponse::err(
+                            StatusCode::BAD_REQUEST,
+                            "invalid locale (needs `.js` extension)",
+                        ))
+                    }
                 };
                 ApiResponse(turbine.get_initial_consts(&locale).await)
             }),

--- a/packages/perseus-axum/src/lib.rs
+++ b/packages/perseus-axum/src/lib.rs
@@ -88,8 +88,12 @@ pub async fn get_router<M: MutableStore + 'static, T: TranslationsManager + 'sta
             get(move || async move { ApiResponse(turbine.get_initial_consts("").await) }),
         )
         .route(
-            "/.perseus/initial_consts/:locale.js",
+            "/.perseus/initial_consts/:locale",
             get(move |Path(locale): Path<String>| async move {
+                let locale = match locale.strip_suffix(".js") {
+                    Some(locale) => locale,
+                    None => return ApiResponse(PerseusApiResponse::err(StatusCode::BAD_REQUEST, "invalid locale (needs `.js` extension)")),
+                };
                 ApiResponse(turbine.get_initial_consts(&locale).await)
             }),
         )

--- a/packages/perseus-warp/src/lib.rs
+++ b/packages/perseus-warp/src/lib.rs
@@ -106,6 +106,14 @@ pub async fn perseus_routes<M: MutableStore + 'static, T: TranslationsManager + 
         warp::path!(".perseus" / "translations" / String).then(move |locale: String| async move {
             ApiResponse(turbine.get_translations(&locale).await)
         });
+    let localized_initial_consts = warp::path!(".perseus" / "initial_consts" / String).then(
+        move |locale: String| async move {
+            let locale = locale.strip_suffix(".js").unwrap_or(&locale);
+            ApiResponse(turbine.get_initial_consts(&locale).await)
+        },
+    );
+    let unlocalized_initial_consts = warp::path!(".perseus" / "initial_consts.js")
+        .then(move || async move { ApiResponse(turbine.get_initial_consts("").await) });
     let page_data = warp::path!(".perseus" / "page" / String / ..)
         .and(warp::path::tail())
         .and(warp::query::<SubsequentLoadQueryParams>())
@@ -172,6 +180,8 @@ pub async fn perseus_routes<M: MutableStore + 'static, T: TranslationsManager + 
         .or(static_dir)
         .or(static_aliases)
         .or(translations)
+        .or(localized_initial_consts)
+        .or(unlocalized_initial_consts)
         .or(page_data)
         .or(initial_loads)
 }

--- a/packages/perseus/src/errors.rs
+++ b/packages/perseus/src/errors.rs
@@ -263,7 +263,7 @@ pub enum ServerError {
     },
     // We should only get a failure to minify if the user has given invalid HTML, or if Sycamore
     // stuffed up somewhere
-    #[error("failed to minify html (you can disable the `minify` flag to avoid this; this is very likely a Sycamore bug, unless you've provided invalid custom HTML)")]
+    #[error("failed to minify html (this is usually caused by semantically invalid html, see https://framesurge.sh/perseus/en-US/docs/0.4.x/faq for details of this problem and how to fix it)")]
     MinifyError {
         #[source]
         source: std::io::Error,

--- a/packages/perseus/src/init.rs
+++ b/packages/perseus/src/init.rs
@@ -822,12 +822,10 @@ impl<G: Html, M: MutableStore, T: TranslationsManager> PerseusAppBase<G, M, T> {
     pub(crate) async fn get_html_shell(
         index_view_str: String,
         root: &str,
-        render_cfg: &HashMap<String, String>,
         plugins: &Plugins,
     ) -> Result<HtmlShell, PluginError> {
         // Construct an HTML shell
-        let mut html_shell =
-            HtmlShell::new(index_view_str, root, render_cfg, &get_path_prefix_server());
+        let mut html_shell = HtmlShell::new(index_view_str, root, &get_path_prefix_server());
 
         // Apply the myriad plugin actions to the HTML shell (replacing the whole thing
         // first if need be)

--- a/packages/perseus/src/state/global_state.rs
+++ b/packages/perseus/src/state/global_state.rs
@@ -43,7 +43,10 @@ make_async_trait!(
 
 #[cfg(engine)]
 make_async_trait!(
-    GlobalStateBuildUserFnType< S: Serialize + DeserializeOwned + MakeRx, V: Into< GeneratorResult<S> > >,
+    GlobalStateBuildUserFnType<
+        S: Serialize + DeserializeOwned + MakeRx,
+        V: Into<GeneratorResult<S>>,
+    >,
     V
 );
 #[cfg(engine)]

--- a/packages/perseus/src/state/global_state.rs
+++ b/packages/perseus/src/state/global_state.rs
@@ -45,7 +45,9 @@ make_async_trait!(
 make_async_trait!(
     GlobalStateBuildUserFnType<
         S: Serialize + DeserializeOwned + MakeRx,
-        V: Into<GeneratorResult<S>>,
+        V: Into<
+        GeneratorResult<S>
+        >,
     >,
     V
 );

--- a/packages/perseus/src/template/widget_component.rs
+++ b/packages/perseus/src/template/widget_component.rs
@@ -128,7 +128,7 @@ impl<G: Html, P: Clone + 'static> Capsule<G, P> {
         // On the browser-side, delayed and non-delayed are the same (it just matters as
         // to what's been preloaded)
         #[cfg(any(client, doc))]
-        return { self.browser_widget(cx, path, props) };
+        return self.browser_widget(cx, path, props);
     }
 
     /// The internal browser-side logic for widgets, both delayed and not.

--- a/packages/perseus/src/turbine/build.rs
+++ b/packages/perseus/src/turbine/build.rs
@@ -109,7 +109,6 @@ impl<M: MutableStore, T: TranslationsManager> Turbine<M, T> {
         let html_shell = PerseusAppBase::<SsrNode, M, T>::get_html_shell(
             self.index_view_str.to_string(),
             &self.root_id,
-            &self.render_cfg,
             &self.plugins,
         )
         .await?;

--- a/packages/perseus/src/turbine/build_error_page.rs
+++ b/packages/perseus/src/turbine/build_error_page.rs
@@ -27,13 +27,12 @@ impl<M: MutableStore, T: TranslationsManager> Turbine<M, T> {
     pub(crate) fn build_error_page(
         &self,
         data: ServerErrorData,
-        // Translator and translations string
-        i18n_data: Option<(&Translator, &str)>,
+        translator: Option<&Translator>,
     ) -> String {
-        let (translator, translations_str, locale) = if let Some((t, s)) = i18n_data {
-            (Some(t), Some(s), Some(t.get_locale()))
+        let (translator, locale) = if let Some(translator) = translator {
+            (Some(translator), Some(translator.get_locale()))
         } else {
-            (None, None, None)
+            (None, None)
         };
 
         let (head, body) = self.error_views.render_to_string(data.clone(), translator);
@@ -43,7 +42,7 @@ impl<M: MutableStore, T: TranslationsManager> Turbine<M, T> {
             .unwrap()
             .clone()
             // This will inject the translations string if it's available
-            .error_page(&data, &body, &head, locale, translations_str)
+            .error_page(&data, &body, &head, locale)
             .to_string()
     }
 }

--- a/packages/perseus/src/turbine/initial_consts.rs
+++ b/packages/perseus/src/turbine/initial_consts.rs
@@ -1,0 +1,51 @@
+use super::Turbine;
+use crate::{errors::ServerError, i18n::TranslationsManager, stores::MutableStore};
+
+/// A template for JS files that define the render configuration and
+/// translations. Until the render configuration is defined, Perseus will not be
+/// instantiated.
+static JS_CONST_FILE_TEMPLATE: &str = r#"window.__PERSEUS_RENDER_CFG = `%render_cfg%`;
+window.__PERSEUS_TRANSLATIONS = `%translations%`;"#;
+
+/// A template for JS files that define the render configuration only. This is
+/// used for unlocalized pages only.
+static JS_UNLOCALIZED_CONST_FILE_TEMPLATE: &str =
+    r#"window.__PERSEUS_RENDER_CFG = `%render_cfg%`;"#;
+
+impl<M: MutableStore, T: TranslationsManager> Turbine<M, T> {
+    /// Creates a JavaScript file containing the render configuration and
+    /// translations data that will also emit a custom event as soon as it
+    /// is ready. This is used by Perseus to avoid sending these data (which
+    /// are generic, but which can be very large), as part of the initial
+    /// HTML bundle. Instead, this file will be requested as part of the bundle,
+    /// and it will inform the Wasm bundle, meaning the user can see a page as
+    /// quickly as possible.
+    ///
+    /// This will assume that the given locale is supported.
+    pub(crate) async fn initial_consts_js(&self, locale: &str) -> Result<String, ServerError> {
+        // If we have no locale, just send the render config (used by unlocalized pages
+        // like some errors and the locale redirection pages)
+        let js_file = if locale.is_empty() {
+            // This is safe to unwrap, we know it will serialize
+            let render_cfg = serde_json::to_string(&self.render_cfg).unwrap();
+            JS_UNLOCALIZED_CONST_FILE_TEMPLATE.replace("%render_cfg%", &render_cfg)
+        } else {
+            let translations = self
+                .translations_manager
+                .get_translations_str_for_locale(locale.to_string())
+                .await;
+            let translations = match translations {
+                Ok(translations) => translations,
+                Err(err) => todo!(),
+            };
+            // This is safe to unwrap, we know it will serialize
+            let render_cfg = serde_json::to_string(&self.render_cfg).unwrap();
+
+            JS_CONST_FILE_TEMPLATE
+                .replace("%render_cfg%", &render_cfg)
+                .replace("%translations%", &translations)
+        };
+
+        Ok(js_file)
+    }
+}

--- a/packages/perseus/src/turbine/mod.rs
+++ b/packages/perseus/src/turbine/mod.rs
@@ -10,6 +10,7 @@ mod build;
 mod build_error_page;
 mod export;
 mod export_error_page;
+mod initial_consts;
 mod serve;
 /// This has the actual API endpoints.
 mod server;
@@ -143,7 +144,6 @@ impl<M: MutableStore, T: TranslationsManager> Turbine<M, T> {
         let html_shell = PerseusAppBase::<SsrNode, M, T>::get_html_shell(
             self.index_view_str.to_string(),
             &self.root_id,
-            &self.render_cfg,
             &self.plugins,
         )
         .await?;


### PR DESCRIPTION
This PR removes the definitions of the render configuration and translations from the HTML bundle in initial loads, instead moving them to `/.perseus/initial_consts/<locale>.js`, with an unlocalized version at `/.perseus/initial_consts.js`. These are new routes that will need to be supported by all server integrations, but otherwise this is not a breaking change, and it purely alters implementation details.

The reason for this change is to change the page load scaling properties of Perseus: right now, very large apps with many pages have longer initial page loads, even for very simple pages, because Perseus injects a JSON sitemap (called the render configuration) into the HTML bundle so it knows how the routing of the app works. So, as the site gets bigger, so does every initial load bundle. To be clear, this effect is usually minimal, and incremental generation has no impact on it (that uses wildcards in the render config), and it does not affect subsequent loads. With this change, the user can load the HTML bundle and then load the JS defining those constants, waiting to instantiate Perseus itself until they are defined. This will marginally increase the page load times of very small sites (incredibly marginally) while significantly decreasing the load times of larger sites and removing any scaling issues: the page load time will be dependent on the page only, not the size of the site.

Note that the process of waiting for constants to be defined is necessary to prevent a fatal error in Perseus itself, but this is done in inlined JS without blocking the main thread, meaning failures will leave the app uninteractive, but still responsive.