### PR TITLE
feat(perseus-cli): add 'node_modules' to watch exclusions

### DIFF
--- a/packages/perseus-cli/src/lib.rs
+++ b/packages/perseus-cli/src/lib.rs
@@ -129,4 +129,4 @@ pub fn get_user_crate_name(dir: &Path) -> Result<String, ExecutionError> {
 /// with these names, rather than any paths with these names. Further exclusions
 /// should be manually specified.*
 pub static WATCH_EXCLUSIONS: &[&str] =
-    &["dist", "target", "target_engine", "target_browser", ".git"];
+    &["dist", "target", "target_engine", "target_browser", ".git", "node_modules"];


### PR DESCRIPTION
### The Problem

Like described inside this issue: [309](https://github.com/framesurge/perseus/issues/309) `perseus serve -w` is very slow when listening to a large number of files. 

### This change

This PR will not fix this in every case but it adds the `node_modules` folder to the watch exclusions. The 'node_modules' folder is similar to the `target` folder but from [npm](https://www.npmjs.com/) and it's often huge. I think a lot of developer has a `node_modules` folder because they are using [bootstrap](https://getbootstrap.com/), [tailwind](https://tailwindcss.com/) or some other npm dependencies inside there perseus projects.