### PR TITLE
docs: clarify the feature flag

### DIFF
--- a/docs/0.4.x/en-US/fundamentals/i18n.md
+++ b/docs/0.4.x/en-US/fundamentals/i18n.md
@@ -6,7 +6,13 @@ When you make your app available in multiple languages, Perseus will automatical
 
 But how do we know what language a user wants their pages in? Some sites figure this out by detecting what country you're in, to the peril of anyone using a VPN who slowly starts to learn Dutch against their will. The much better way of doing this is to just ask the browser, because users can configure their browsers with an arbitrary number of ordered locale preferences. For example, a Chinese native speaker who lives in Germany but is fluent in English might number her preferences as: `zh-CN`, `de-DE`, `en`, in that order. Notice the lack of a region code on the final preference (this is common). The process of *locale detection* is a complex one that requires comparing the languages an app has available with those a user would like to see. Unlike all other current frameworks, Perseus performs this process totally automatically according to web standards (see [RFC 4647](https://www.rfc-editor.org/rfc/rfc4647)). So, if our Chinese-German English speaker from before goes to `/about`, she will be redirected to `/en-US/about` automatically (since her first two preferences are unavailable). From here, any links will keep her in the `en-US` locale.
 
-You can set up internationalization in your app through `PerseusApp` like so:
+To set up internationalization in your app through `PerseusApp`, you need to add the feature flag `translator-fluent` or `translator-lightweight` in your `Cargo.toml` file. We will discuss the differences between these flags later.
+
+```rust
+{{#include ../../../examples/core/i18n/Cargo.toml}}
+```
+
+Here is an example in `main.rs`:
 
 ```rust
 {{#include ../../../examples/core/i18n/src/main.rs}}


### PR DESCRIPTION
To clarify, the feature flag for internationalization must be added to `Cargo.toml` to enable the i18n feature.