### PR TITLE
deps: Bump Fluent crates to latest minor releases

### DIFF
--- a/examples/core/i18n/Cargo.toml
+++ b/examples/core/i18n/Cargo.toml
@@ -11,7 +11,7 @@ perseus = { path = "../../../packages/perseus", features = [ "translator-fluent"
 sycamore = "^0.8.1"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
-fluent-bundle = "0.15"
+fluent-bundle = "0.16"
 urlencoding = "2.1"
 
 [dev-dependencies]

--- a/packages/perseus/Cargo.toml
+++ b/packages/perseus/Cargo.toml
@@ -24,7 +24,7 @@ thiserror = "1"
 async-trait = "0.1"
 futures = "0.3"
 fmterr = "0.1"
-fluent-bundle = { version = "0.15", optional = true }
+fluent-bundle = { version = "0.16", optional = true }
 unic-langid = { version = "0.9", optional = true }
 intl-memoizer = { version = "0.5", optional = true }
 


### PR DESCRIPTION
I just released a breaking version (minor version because we're stuck in zero-ver teritory) to the upstream Fluent crate(s). I see they are used here, but I don't think any of the upstream changes will actually be breaking for this project so a simple bump should be sufficient.

I was not able to test this due to build/check/test failures that seem to be unrelated to this bump. Given that your CI suite seems to be all red right now I suspect the repo is just in a broken state right now. You could test this rebased against something that is known to work.
